### PR TITLE
fix: 테스트용 팩토리 메서드이동

### DIFF
--- a/src/main/java/jinookk/ourlms/models/entities/Account.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Account.java
@@ -53,17 +53,6 @@ public class Account {
         this.userName = userName;
     }
 
-    public static Account fake(String name) {
-        return fake(new Name(name, false));
-    }
-
-    private static Account fake(Name name) {
-        UserName userName = new UserName("ojw0828@naver.com");
-        Long id = 1L;
-
-        return new Account(id, name, userName);
-    }
-
     public static Account of(RegisterRequestDto registerRequestDto) {
         Name name = new Name(registerRequestDto.getName(), false);
         UserName userName = new UserName(registerRequestDto.getUserName());

--- a/src/main/java/jinookk/ourlms/models/entities/Cart.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Cart.java
@@ -38,10 +38,6 @@ public class Cart {
         this.accountId = accountId;
     }
 
-    public static Cart fake(AccountId accountId) {
-        return new Cart(accountId);
-    }
-
     public static Cart of(AccountId accountId) {
         return new Cart(accountId);
     }

--- a/src/main/java/jinookk/ourlms/models/entities/Category.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Category.java
@@ -31,14 +31,6 @@ public class Category {
         this.url = url;
     }
 
-    public static Category fake(String content) {
-        return fake(new Content(content));
-    }
-
-    private static Category fake(Content content) {
-        return new Category(content, "url");
-    }
-
     public static Category of(CategoryRequestDto categoryRequestDto) {
         return new Category(new Content(categoryRequestDto.getCategory()), categoryRequestDto.getUrl());
     }

--- a/src/main/java/jinookk/ourlms/models/entities/Comment.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Comment.java
@@ -65,24 +65,18 @@ public class Comment {
         this.publishTime = publishTime;
     }
 
-    // 댓글 생성
     public static Comment of(Inquiry inquiry, List<Comment> comments, CommentRequestDto commentRequestDto,
                              Account account, Course course) {
-        // 새로 만들어진 댓글이 강사의 것인지  여부 확인 -> 맞으면 답변?
         if (course.isInstructor(new AccountId(account.id()))) {
             inquiry.reply();
         }
 
-        //  작성자의 아이디인지 확인 -> 맞다면 comment를 Inquiry의 이름을 이용해서 댓글을 생성한다.
-//      ? 필요한지 잘 모르겠네 -> 글 작성자가 익명인지 확인해야함. 근데 이건 너무 주먹 구구식인것 같다.
         if (inquiry.isPublisherId(new AccountId(account.id()))) {
             return Comment.of(commentRequestDto, inquiry.publisher(), inquiry.accountId());
         }
 
         Optional<Comment> previousComment = inquiry.previousComment(comments, new AccountId(account.id()));
 
-        // 이전 댓글이 존재하면 이전 댓글을 읽어서 이름을 가져온다.
-        // 왜 이렇게 복잡해졌을까? -> 책임이 제대로 나뉘어 있지 않아서 그런 것 같다.
         if (previousComment.isPresent()) {
             Name author = previousComment.get().author();
             return Comment.of(commentRequestDto, author, new AccountId(account.id()));
@@ -129,15 +123,6 @@ public class Comment {
         LocalDateTime publishTime = LocalDateTime.now();
 
         return new Comment(id, inquiryId, accountId, status, publisher, content, publishTime);
-    }
-
-    private static Comment fake(Content content) {
-        return new Comment(11L, new InquiryId(1L), new AccountId(1L), new Status(Status.CREATED),
-                new Name("1st Tester", false), content, LocalDateTime.now());
-    }
-
-    public static Comment fake(String content) {
-        return fake(new Content(content));
     }
 
     public CommentDto toCommentDto() {

--- a/src/main/java/jinookk/ourlms/models/entities/Course.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Course.java
@@ -133,23 +133,6 @@ public class Course {
         return status;
     }
 
-    public static Course fake(String title) {
-        return fake(new Title(title));
-    }
-
-    private static Course fake(Title title) {
-        Long id = 1L;
-        ImagePath imagePath = new ImagePath("imagePath");
-        Category category = new Category("category");
-        Name instructor = new Name("instructor", false);
-        AccountId accountId = new AccountId(1L);
-        Content description = new Content("description");
-        Price price = new Price(10000);
-        Status status = new Status(Status.PROCESSING);
-
-        return new Course(id, title, description, status, imagePath, category, instructor, accountId, price);
-    }
-
     public Course changeLevel(Level level) {
         this.level = level;
 

--- a/src/main/java/jinookk/ourlms/models/entities/Inquiry.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Inquiry.java
@@ -80,10 +80,6 @@ public class Inquiry {
 
     private LocalDateTime repliedAt;
 
-    // accountId가 존재하는 inquiryId의 수를 찾아라.
-//    @Formula("(SELECT COUNT(*) FROM inquiry_likes l WHERE l.inquiry_id = id)")
-//    private int countOfLikes;
-
     public Inquiry() {
     }
 
@@ -102,20 +98,6 @@ public class Inquiry {
         this.anonymous = anonymous;
         this.publishTime = publishTime;
         this.repliedAt = repliedAt;
-    }
-
-    public static Inquiry fake(String content) {
-        return fake(new Content(content));
-    }
-
-    private static Inquiry fake(Content content) {
-        return new Inquiry(1L, new CourseId(1L), new LectureId(1L), new AccountId(1L), List.of(), new Title("title"), content,
-                new LectureTime(1, 24), new Name("tester", false), false, LocalDateTime.now(), LocalDateTime.now());
-    }
-
-    public static Inquiry fake(Name publisher) {
-        return new Inquiry(1L, new CourseId(1L), new LectureId(1L), new AccountId(1L), List.of(), new Title("title"),
-                new Content("hi"), new LectureTime(1, 24), publisher, false, LocalDateTime.now(), LocalDateTime.now());
     }
 
     public static Inquiry of(InquiryRequestDto inquiryRequestDto, AccountId accountId, Name name) {

--- a/src/main/java/jinookk/ourlms/models/entities/Lecture.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Lecture.java
@@ -72,33 +72,6 @@ public class Lecture {
         this.videoUrl = videoUrl;
     }
 
-    public static Lecture fake(String lectureTitle) {
-        return fake(new Title(lectureTitle));
-    }
-
-    private static Lecture fake(Title title) {
-        Long id = 1L;
-        CourseId courseId = new CourseId(1L);
-        Content lectureNote = new Content("lectureNote");
-        SectionId sectionId = new SectionId(1L);
-        HandOutUrl handOutUrl = new HandOutUrl("url");
-        VideoUrl videoUrl = new VideoUrl("video/url");
-
-        return new Lecture(id, courseId, sectionId, title, lectureNote, handOutUrl, videoUrl);
-    }
-
-    public static Lecture fake(LectureId lectureId) {
-        Long id = lectureId.value();
-        CourseId courseId = new CourseId(1L);
-        Content lectureNote = new Content("lectureNote");
-        SectionId sectionId = new SectionId(1L);
-        Title title = new Title("title");
-        HandOutUrl handOutUrl = new HandOutUrl("url");
-        VideoUrl videoUrl = new VideoUrl("video/url");
-
-        return new Lecture(id, courseId, sectionId, title, lectureNote, handOutUrl, videoUrl);
-    }
-
     public static Lecture of(LectureRequestDto lectureRequestDto) {
         return new Lecture(
                 null,

--- a/src/main/java/jinookk/ourlms/models/entities/Like.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Like.java
@@ -39,10 +39,6 @@ public class Like {
         this.clicked = clicked;
     }
 
-    public static Like fake(Boolean clicked) {
-        return new Like(new AccountId(1L), new CourseId(1L), clicked);
-    }
-
     public static List<Like> listOf(AccountId accountId, List<CourseId> courseIds) {
         return courseIds.stream()
                 .map(courseId -> Like.of(accountId, courseId))

--- a/src/main/java/jinookk/ourlms/models/entities/Note.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Note.java
@@ -60,15 +60,6 @@ public class Note {
         this.publishTime = publishTime;
     }
 
-    public static Note fake(String content) {
-        return fake(new Content(content));
-    }
-
-    private static Note fake(Content content) {
-        return new Note(1L, new LectureId(1L), new AccountId(1L), new Status(Status.CREATED), content,
-                new LectureTime(1, 24), LocalDateTime.now());
-    }
-
     public static Note of(NoteRequestDto noteRequestDto, AccountId accountId) {
         return new Note(null, new LectureId(noteRequestDto.getLectureId()), accountId,
                 new Status(Status.CREATED), new Content(noteRequestDto.getContent()),

--- a/src/main/java/jinookk/ourlms/models/entities/Payment.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Payment.java
@@ -60,15 +60,6 @@ public class Payment {
         this.createdAt = createdAt;
     }
 
-    public static Payment fake(int price) {
-        return fake(new Price(price));
-    }
-
-    private static Payment fake(Price price) {
-        return new Payment(1L, new CourseId(1L), new AccountId(1L), price, new Title("course title"),
-                new Name("purchaser", false), LocalDateTime.now());
-    }
-
     public static List<Payment> listOf(List<Course> courses, Account account, Cart cart) {
         if (account == null || courses == null || courses.size() == 0 ) {
             throw new InvalidPaymentInformation();

--- a/src/main/java/jinookk/ourlms/models/entities/Progress.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Progress.java
@@ -63,14 +63,6 @@ public class Progress {
         this.title = title;
     }
 
-    public static Progress fake(String lectureTitle) {
-        return fake(new Title(lectureTitle));
-    }
-
-    private static Progress fake(Title title) {
-        return new Progress(31L, new CourseId(1L), new AccountId(1L), new LectureId(1L), title);
-    }
-
     public static Progress of(Lecture lecture, AccountId accountId) {
         if (lecture == null || accountId == null || accountId.value() == null) {
             throw new InvalidArgument();

--- a/src/main/java/jinookk/ourlms/models/entities/Rating.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Rating.java
@@ -83,10 +83,6 @@ public class Rating {
         return average / filtered.size();
     }
 
-    public static Rating fake(Double point) {
-        return new Rating(1L, new AccountId(1L), new CourseId(1L), new Name("author", false), new Content("content"), point);
-    }
-
     public Long id() {
         return id;
     }

--- a/src/main/java/jinookk/ourlms/models/entities/RefreshToken.java
+++ b/src/main/java/jinookk/ourlms/models/entities/RefreshToken.java
@@ -29,11 +29,6 @@ public class RefreshToken {
         return new RefreshToken(userName, tokenValue);
     }
 
-    public static RefreshToken fake(String expired) {
-        return new RefreshToken("tester@email.com", expired);
-    }
-
-
     public String tokenValue() {
         return tokenValue;
     }

--- a/src/main/java/jinookk/ourlms/models/entities/Section.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Section.java
@@ -77,14 +77,6 @@ public class Section {
         return goal;
     }
 
-    public static Section fake(String title) {
-        return fake(new Title(title));
-    }
-
-    private static Section fake(Title title) {
-        return new Section(1L, new CourseId(1L), new Status(Status.CREATED), title, new Content("goal"));
-    }
-
     public SectionWithProgressDto toSectionWithProgressDto(List<Progress> progresses) {
         if (progresses == null) {
             return new SectionWithProgressDto(id, title, List.of());

--- a/src/main/java/jinookk/ourlms/models/entities/Skill.java
+++ b/src/main/java/jinookk/ourlms/models/entities/Skill.java
@@ -26,10 +26,6 @@ public class Skill {
         return new Skill(skillRequestDto.getSkillTag());
     }
 
-    public static Skill fake(String skill) {
-        return new Skill(skill);
-    }
-
     public SkillDto toDto() {
         return new SkillDto(id, content);
     }

--- a/src/test/java/jinookk/ourlms/applications/cart/AddCartItemServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/cart/AddCartItemServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.cart;
 
 import jinookk.ourlms.dtos.CartDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Cart;
 import jinookk.ourlms.models.vos.UserName;
@@ -19,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class AddCartItemServiceTest {
+class AddCartItemServiceTest extends Fixture {
     AddCartItemService addCartItemService;
     CartRepository cartRepository;
     AccountRepository accountRepository;
@@ -32,7 +33,7 @@ class AddCartItemServiceTest {
 
         List<CourseId> courseIds = List.of(new CourseId(1L), new CourseId(2L));
 
-        Cart cart = Cart.fake(new AccountId(1L));
+        Cart cart = Fixture.cart(new AccountId(1L));
 
         for (CourseId courseId : courseIds) {
             cart = cart.addItem(courseId.value());
@@ -40,7 +41,7 @@ class AddCartItemServiceTest {
 
         given(cartRepository.findByAccountId(new AccountId(1L))).willReturn(Optional.of(cart));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/cart/DeleteCartItemServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/cart/DeleteCartItemServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.cart;
 
 import jinookk.ourlms.dtos.CartDto;
 import jinookk.ourlms.dtos.CartRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Cart;
 import jinookk.ourlms.models.vos.UserName;
@@ -20,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class DeleteCartItemServiceTest {
+class DeleteCartItemServiceTest extends Fixture{
     DeleteCartItemService deleteCartItemService;
     CartRepository cartRepository;
     AccountRepository accountRepository;
@@ -33,7 +34,7 @@ class DeleteCartItemServiceTest {
 
         List<CourseId> courseIds = List.of(new CourseId(1L), new CourseId(2L));
 
-        Cart cart = Cart.fake(new AccountId(1L));
+        Cart cart = Fixture.cart(new AccountId(1L));
 
         for (CourseId courseId : courseIds) {
             cart = cart.addItem(courseId.value());
@@ -41,7 +42,7 @@ class DeleteCartItemServiceTest {
 
         given(cartRepository.findByAccountId(new AccountId(1L))).willReturn(Optional.of(cart));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/cart/GetCartServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/cart/GetCartServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.cart;
 
 import jinookk.ourlms.dtos.CartDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Cart;
 import jinookk.ourlms.models.vos.UserName;
@@ -19,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetCartServiceTest {
+class GetCartServiceTest extends Fixture {
     GetCartService getCartService;
     CartRepository cartRepository;
     AccountRepository accountRepository;
@@ -32,7 +33,7 @@ class GetCartServiceTest {
 
         List<CourseId> courseIds = List.of(new CourseId(1L), new CourseId(2L));
 
-        Cart cart = Cart.fake(new AccountId(1L));
+        Cart cart = Fixture.cart(new AccountId(1L));
 
         for (CourseId courseId : courseIds) {
             cart = cart.addItem(courseId.value());
@@ -40,7 +41,7 @@ class GetCartServiceTest {
 
         given(cartRepository.findByAccountId(new AccountId(1L))).willReturn(Optional.of(cart));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/category/CreateCategoryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/category/CreateCategoryServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.category;
 
 import jinookk.ourlms.dtos.CategoryDto;
 import jinookk.ourlms.dtos.CategoryRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Category;
 import jinookk.ourlms.repositories.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class CreateCategoryServiceTest {
 
     @Test
     void post() {
-        Category category = Category.fake("category");
+        Category category = Fixture.category("category");
 
         given(categoryRepository.save(any())).willReturn(category);
 

--- a/src/test/java/jinookk/ourlms/applications/category/DeleteCategoryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/category/DeleteCategoryServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.category;
 
 import jinookk.ourlms.dtos.CategoryDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Category;
 import jinookk.ourlms.repositories.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,7 @@ class DeleteCategoryServiceTest {
 
     @Test
     void delete() {
-        Category category = Category.fake("category");
+        Category category = Fixture.category("category");
 
         given(categoryRepository.findById(any())).willReturn(Optional.of(category));
 

--- a/src/test/java/jinookk/ourlms/applications/category/GetCategoryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/category/GetCategoryServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.category;
 
 import jinookk.ourlms.dtos.CategoriesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Category;
 import jinookk.ourlms.repositories.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class GetCategoryServiceTest {
 
     @Test
     void list() {
-        Category category = Category.fake("category");
+        Category category = Fixture.category("category");
 
         given(categoryRepository.findAll()).willReturn(List.of(category));
 

--- a/src/test/java/jinookk/ourlms/applications/comment/CreateCommentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/comment/CreateCommentServiceTest.java
@@ -3,6 +3,7 @@ package jinookk.ourlms.applications.comment;
 import jinookk.ourlms.dtos.CommentDto;
 import jinookk.ourlms.dtos.CommentRequestDto;
 import jinookk.ourlms.dtos.CommentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Comment;
 import jinookk.ourlms.models.entities.Course;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class CreateCommentServiceTest {
+class CreateCommentServiceTest extends Fixture {
     CreateCommentService createCommentService;
     CommentRepository commentRepository;
     InquiryRepository inquiryRepository;
@@ -46,20 +47,20 @@ class CreateCommentServiceTest {
         courseRepository = mock(CourseRepository.class);
         createCommentService = new CreateCommentService(commentRepository, inquiryRepository, accountRepository, courseRepository);
 
-        Comment comment = Comment.fake("hi");
-        Comment comment2 = Comment.fake("hi2");
-        Comment comment3 = Comment.fake("hi3");
+        Comment comment = Fixture.comment("hi");
+        Comment comment2 = Fixture.comment("hi2");
+        Comment comment3 = Fixture.comment("hi3");
         given(commentRepository.save(any())).willReturn(comment);
 
         given(commentRepository.findAllByInquiryId(new InquiryId(1L))).willReturn(List.of(comment, comment2, comment3));
 
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
         given(courseRepository.findById(any())).willReturn(Optional.of(course));
 
-        Inquiry inquiry = Inquiry.fake("inquiry");
+        Inquiry inquiry = Fixture.inquiry("inquiry");
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
 
-        Account account = Account.fake("tester2");
+        Account account = Fixture.account("tester2");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/comment/DeleteCommentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/comment/DeleteCommentServiceTest.java
@@ -1,37 +1,26 @@
 package jinookk.ourlms.applications.comment;
 
-import jinookk.ourlms.dtos.CommentDto;
-import jinookk.ourlms.dtos.CommentRequestDto;
-import jinookk.ourlms.dtos.CommentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Comment;
-import jinookk.ourlms.models.entities.Course;
-import jinookk.ourlms.models.entities.Inquiry;
-import jinookk.ourlms.models.vos.Content;
-import jinookk.ourlms.models.vos.Name;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.ids.InquiryId;
-import jinookk.ourlms.models.vos.status.Status;
 import jinookk.ourlms.repositories.AccountRepository;
 import jinookk.ourlms.repositories.CommentRepository;
-import jinookk.ourlms.repositories.CourseRepository;
-import jinookk.ourlms.repositories.InquiryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class DeleteCommentServiceTest {
+class DeleteCommentServiceTest extends Fixture {
     DeleteCommentService deleteCommentService;
     CommentRepository commentRepository;
     AccountRepository accountRepository;
@@ -42,20 +31,20 @@ class DeleteCommentServiceTest {
         commentRepository = mock(CommentRepository.class);
         deleteCommentService = new DeleteCommentService(commentRepository, accountRepository);
 
-        Comment comment = Comment.fake("hi");
-        Comment comment2 = Comment.fake("hi2");
-        Comment comment3 = Comment.fake("hi3");
+        Comment comment = Fixture.comment("hi");
+        Comment comment2 = Fixture.comment("hi2");
+        Comment comment3 = Fixture.comment("hi3");
         given(commentRepository.save(any())).willReturn(comment);
 
         given(commentRepository.findAllByInquiryId(new InquiryId(1L))).willReturn(List.of(comment, comment2, comment3));
 
-        Account account = Account.fake("tester2");
+        Account account = Fixture.account("tester2");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 
     @Test
     void delete() {
-        Comment comment = spy(Comment.fake("hi"));
+        Comment comment = spy(Fixture.comment("hi"));
 
         given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
 

--- a/src/test/java/jinookk/ourlms/applications/comment/GetCommentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/comment/GetCommentServiceTest.java
@@ -1,26 +1,16 @@
 package jinookk.ourlms.applications.comment;
 
-import jinookk.ourlms.dtos.CommentDto;
-import jinookk.ourlms.dtos.CommentRequestDto;
 import jinookk.ourlms.dtos.CommentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Comment;
-import jinookk.ourlms.models.entities.Course;
-import jinookk.ourlms.models.entities.Inquiry;
-import jinookk.ourlms.models.vos.Content;
-import jinookk.ourlms.models.vos.Name;
 import jinookk.ourlms.models.vos.UserName;
-import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.ids.InquiryId;
-import jinookk.ourlms.models.vos.status.Status;
 import jinookk.ourlms.repositories.AccountRepository;
 import jinookk.ourlms.repositories.CommentRepository;
-import jinookk.ourlms.repositories.CourseRepository;
-import jinookk.ourlms.repositories.InquiryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,10 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
-class GetCommentServiceTest {
+class GetCommentServiceTest extends Fixture {
     GetCommentService getCommentService;
     CommentRepository commentRepository;
     AccountRepository accountRepository;
@@ -42,14 +30,14 @@ class GetCommentServiceTest {
         commentRepository = mock(CommentRepository.class);
         getCommentService = new GetCommentService(commentRepository, accountRepository);
 
-        Comment comment = Comment.fake("hi");
-        Comment comment2 = Comment.fake("hi2");
-        Comment comment3 = Comment.fake("hi3");
+        Comment comment = Fixture.comment("hi");
+        Comment comment2 = Fixture.comment("hi2");
+        Comment comment3 = Fixture.comment("hi3");
         given(commentRepository.save(any())).willReturn(comment);
 
         given(commentRepository.findAllByInquiryId(new InquiryId(1L))).willReturn(List.of(comment, comment2, comment3));
 
-        Account account = Account.fake("tester2");
+        Account account = Fixture.account("tester2");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/comment/UpdateCommentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/comment/UpdateCommentServiceTest.java
@@ -1,37 +1,26 @@
 package jinookk.ourlms.applications.comment;
 
-import jinookk.ourlms.dtos.CommentDto;
-import jinookk.ourlms.dtos.CommentRequestDto;
-import jinookk.ourlms.dtos.CommentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Comment;
-import jinookk.ourlms.models.entities.Course;
-import jinookk.ourlms.models.entities.Inquiry;
-import jinookk.ourlms.models.vos.Content;
-import jinookk.ourlms.models.vos.Name;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.ids.InquiryId;
-import jinookk.ourlms.models.vos.status.Status;
 import jinookk.ourlms.repositories.AccountRepository;
 import jinookk.ourlms.repositories.CommentRepository;
-import jinookk.ourlms.repositories.CourseRepository;
-import jinookk.ourlms.repositories.InquiryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-class UpdateCommentServiceTest {
+class UpdateCommentServiceTest extends Fixture {
     UpdateCommentService updateCommentService;
     CommentRepository commentRepository;
     AccountRepository accountRepository;
@@ -42,20 +31,20 @@ class UpdateCommentServiceTest {
         commentRepository = mock(CommentRepository.class);
         updateCommentService = new UpdateCommentService(commentRepository, accountRepository);
 
-        Comment comment = Comment.fake("hi");
-        Comment comment2 = Comment.fake("hi2");
-        Comment comment3 = Comment.fake("hi3");
+        Comment comment = Fixture.comment("hi");
+        Comment comment2 = Fixture.comment("hi2");
+        Comment comment3 = Fixture.comment("hi3");
         given(commentRepository.save(any())).willReturn(comment);
 
         given(commentRepository.findAllByInquiryId(new InquiryId(1L))).willReturn(List.of(comment, comment2, comment3));
 
-        Account account = Account.fake("tester2");
+        Account account = Fixture.account("tester2");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 
     @Test
     void update() {
-        Comment comment = spy(Comment.fake("hi"));
+        Comment comment = spy(Fixture.comment("hi"));
 
         given(commentRepository.findById(1L)).willReturn(Optional.of(comment));
 

--- a/src/test/java/jinookk/ourlms/applications/course/CreateCourseServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/course/CreateCourseServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.course;
 
 import jinookk.ourlms.dtos.CourseRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.enums.Level;
@@ -21,7 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class CreateCourseServiceTest {
+class CreateCourseServiceTest extends Fixture {
     CreateCourseService courseService;
     CourseRepository courseRepository;
     AccountRepository accountRepository;
@@ -32,8 +33,8 @@ class CreateCourseServiceTest {
         courseRepository = mock(CourseRepository.class);
         courseService = new CreateCourseService(courseRepository, accountRepository);
 
-        Course course = Course.fake("내 강의");
-        Account account = Account.fake("account");
+        Course course = Fixture.course("내 강의");
+        Account account = Fixture.account("account");
 
         Page<Course> courses = new PageImpl<>(List.of(course));
 

--- a/src/test/java/jinookk/ourlms/applications/course/DeleteCourseServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/course/DeleteCourseServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.course;
 
 import jinookk.ourlms.dtos.CourseDto;
 import jinookk.ourlms.dtos.CourseUpdateRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.vos.HashTag;
@@ -25,7 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class DeleteCourseServiceTest {
+class DeleteCourseServiceTest extends Fixture{
     DeleteCourseService courseService;
     CourseRepository courseRepository;
     AccountRepository accountRepository;
@@ -36,8 +37,8 @@ class DeleteCourseServiceTest {
         courseRepository = mock(CourseRepository.class);
         courseService = new DeleteCourseService(courseRepository, accountRepository);
 
-        Course course = Course.fake("내 강의");
-        Account account = Account.fake("account");
+        Course course = Fixture.course("내 강의");
+        Account account = Fixture.account("account");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 
@@ -52,7 +53,7 @@ class DeleteCourseServiceTest {
 
     @Test
     void delete() {
-        Course course = Course.fake("updated");
+        Course course = Fixture.course("updated");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 
@@ -63,7 +64,7 @@ class DeleteCourseServiceTest {
 
     @Test
     void deleteSkill() {
-        Course course = Course.fake("updated");
+        Course course = Fixture.course("updated");
 
         CourseUpdateRequestDto courseUpdateRequestDto = new CourseUpdateRequestDto(
                 "updated", "category", "description", "thumbnailPath", "", "초급", List.of("스킬"), 0);

--- a/src/test/java/jinookk/ourlms/applications/course/GetCourseServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/course/GetCourseServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.course;
 
 import jinookk.ourlms.applications.dtos.GetCoursesDto;
 import jinookk.ourlms.dtos.CourseDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Like;
@@ -25,7 +26,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class GetCourseServiceTest {
+class GetCourseServiceTest extends Fixture {
     GetCourseService getCourseService;
     CourseRepository courseRepository;
     AccountRepository accountRepository;
@@ -38,8 +39,8 @@ class GetCourseServiceTest {
         courseRepository = mock(CourseRepository.class);
         getCourseService = new GetCourseService(courseRepository, accountRepository, likeRepository);
 
-        Course course = Course.fake("내 강의");
-        Account account = Account.fake("account");
+        Course course = Fixture.course("내 강의");
+        Account account = Fixture.account("account");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 
@@ -50,7 +51,7 @@ class GetCourseServiceTest {
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
         given(courseRepository.save(any())).willReturn(course);
 
-        Like like = Like.fake(true);
+        Like like = Fixture.like(true);
         given(likeRepository.findAllByAccountId(any())).willReturn(List.of(like));
 
         given(courseRepository.findAllById(any())).willReturn(List.of(course));

--- a/src/test/java/jinookk/ourlms/applications/course/MyCourseServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/course/MyCourseServiceTest.java
@@ -1,8 +1,7 @@
 package jinookk.ourlms.applications.course;
 
-import jinookk.ourlms.applications.course.MyCourseService;
 import jinookk.ourlms.applications.dtos.GetCoursesDto;
-import jinookk.ourlms.dtos.CoursesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Payment;
@@ -23,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class MyCourseServiceTest {
+class MyCourseServiceTest extends Fixture {
     MyCourseService myCourseService;
     CourseRepository courseRepository;
     PaymentRepository paymentRepository;
@@ -36,16 +35,16 @@ class MyCourseServiceTest {
         courseRepository = mock(CourseRepository.class);
         myCourseService = new MyCourseService(courseRepository, paymentRepository, accountRepository);
 
-        Payment payment = Payment.fake(35_000);
+        Payment payment = Fixture.payment(35_000);
         given(paymentRepository.findAllByAccountId(any())).willReturn(List.of(payment));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 
     @Test
     void purchasedList() {
-        Course course = Course.fake("test");
+        Course course = Fixture.course("test");
 
         given(courseRepository.findAllById(any()))
                 .willReturn(List.of(course));
@@ -57,7 +56,7 @@ class MyCourseServiceTest {
 
     @Test
     void uploadedList() {
-        Course course = Course.fake("test");
+        Course course = Fixture.course("test");
 
         given(courseRepository.findAllByAccountId(new AccountId(1L)))
                 .willReturn(List.of(course));

--- a/src/test/java/jinookk/ourlms/applications/course/UpdateCourseServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/course/UpdateCourseServiceTest.java
@@ -3,6 +3,7 @@ package jinookk.ourlms.applications.course;
 import jinookk.ourlms.dtos.CourseDto;
 import jinookk.ourlms.dtos.CourseUpdateRequestDto;
 import jinookk.ourlms.dtos.StatusUpdateDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.vos.UserName;
@@ -22,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class UpdateCourseServiceTest {
+class UpdateCourseServiceTest extends Fixture {
     UpdateCourseService updateCourseService;
     CourseRepository courseRepository;
     AccountRepository accountRepository;
@@ -33,8 +34,8 @@ class UpdateCourseServiceTest {
         courseRepository = mock(CourseRepository.class);
         updateCourseService = new UpdateCourseService(courseRepository, accountRepository);
 
-        Course course = Course.fake("내 강의");
-        Account account = Account.fake("account");
+        Course course = Fixture.course("내 강의");
+        Account account = Fixture.account("account");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 
@@ -49,7 +50,7 @@ class UpdateCourseServiceTest {
 
     @Test
     void update() {
-        Course course = Course.fake("updated");
+        Course course = Fixture.course("updated");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 
@@ -62,7 +63,7 @@ class UpdateCourseServiceTest {
 
     @Test
     void updateStatus() {
-        Course course = Course.fake("updated");
+        Course course = Fixture.course("updated");
 
         given(courseRepository.findById(1L)).willReturn(Optional.of(course));
 

--- a/src/test/java/jinookk/ourlms/applications/inquiry/CreateInquiryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/inquiry/CreateInquiryServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.inquiry;
 
 import jinookk.ourlms.dtos.InquiryDto;
 import jinookk.ourlms.dtos.InquiryRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Inquiry;
 import jinookk.ourlms.models.vos.UserName;
@@ -20,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class CreateInquiryServiceTest {
+class CreateInquiryServiceTest extends Fixture{
     CreateInquiryService createInquiryService;
     InquiryRepository inquiryRepository;
     AccountRepository accountRepository;
@@ -31,8 +32,8 @@ class CreateInquiryServiceTest {
         inquiryRepository = mock(InquiryRepository.class);
         createInquiryService = new CreateInquiryService(inquiryRepository, accountRepository);
 
-        Inquiry inquiry1 = Inquiry.fake("inquiry1");
-        Inquiry inquiry2 = Inquiry.fake("inquiry2");
+        Inquiry inquiry1 = Fixture.inquiry("inquiry1");
+        Inquiry inquiry2 = Fixture.inquiry("inquiry2");
 
         given(inquiryRepository.save(any())).willReturn(inquiry1);
 
@@ -42,7 +43,7 @@ class CreateInquiryServiceTest {
 
         given(inquiryRepository.findAllByAccountId(any())).willReturn(List.of(inquiry1, inquiry2));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
 
         given(inquiryRepository.findAllByCourseId(new CourseId(1L))).willReturn(List.of(inquiry1, inquiry2));

--- a/src/test/java/jinookk/ourlms/applications/inquiry/DeleteInquiryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/inquiry/DeleteInquiryServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.inquiry;
 
 import jinookk.ourlms.dtos.InquiryDeleteDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Inquiry;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.models.vos.ids.InquiryId;
@@ -25,8 +26,8 @@ class DeleteInquiryServiceTest {
         inquiryRepository = mock(InquiryRepository.class);
         deleteInquiryService = new DeleteInquiryService(inquiryRepository);
 
-        Inquiry inquiry1 = Inquiry.fake("inquiry1");
-        Inquiry inquiry2 = Inquiry.fake("inquiry2");
+        Inquiry inquiry1 = Fixture.inquiry("inquiry1");
+        Inquiry inquiry2 = Fixture.inquiry("inquiry2");
 
         given(inquiryRepository.save(any())).willReturn(inquiry1);
 

--- a/src/test/java/jinookk/ourlms/applications/inquiry/GetInquiryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/inquiry/GetInquiryServiceTest.java
@@ -3,6 +3,7 @@ package jinookk.ourlms.applications.inquiry;
 import jinookk.ourlms.dtos.InquiriesDto;
 import jinookk.ourlms.dtos.InquiryDto;
 import jinookk.ourlms.dtos.InquiryFilterDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Inquiry;
@@ -27,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetInquiryServiceTest {
+class GetInquiryServiceTest extends Fixture {
     GetInquiryService getInquiryService;
     InquiryRepository inquiryRepository;
     AccountRepository accountRepository;
@@ -42,8 +43,8 @@ class GetInquiryServiceTest {
         inquiryRepository = mock(InquiryRepository.class);
         getInquiryService = new GetInquiryService(inquiryRepository, accountRepository, courseRepository, lectureRepository);
 
-        Inquiry inquiry1 = Inquiry.fake("inquiry1");
-        Inquiry inquiry2 = Inquiry.fake("inquiry2");
+        Inquiry inquiry1 = Fixture.inquiry("inquiry1");
+        Inquiry inquiry2 = Fixture.inquiry("inquiry2");
 
         given(inquiryRepository.save(any())).willReturn(inquiry1);
 
@@ -53,14 +54,14 @@ class GetInquiryServiceTest {
 
         given(inquiryRepository.findAllByAccountId(any())).willReturn(List.of(inquiry1, inquiry2));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
 
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
         given(courseRepository.findAllByAccountId(new AccountId(1L))).willReturn(List.of(course));
 
-        Lecture lecture1 = Lecture.fake("lecture1");
-        Lecture lecture2 = Lecture.fake("lecture2");
+        Lecture lecture1 = Fixture.lecture("lecture1");
+        Lecture lecture2 = Fixture.lecture("lecture2");
         given(lectureRepository.findAllByCourseId(new CourseId(1L))).willReturn(List.of(lecture1, lecture2));
 
         given(inquiryRepository.findAllByCourseId(new CourseId(1L))).willReturn(List.of(inquiry1, inquiry2));

--- a/src/test/java/jinookk/ourlms/applications/inquiry/UpdateInquiryServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/inquiry/UpdateInquiryServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.inquiry;
 
 import jinookk.ourlms.dtos.InquiryDto;
 import jinookk.ourlms.dtos.InquiryUpdateDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Inquiry;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.models.vos.ids.InquiryId;
@@ -26,8 +27,8 @@ class UpdateInquiryServiceTest {
         inquiryRepository = mock(InquiryRepository.class);
         updateInquiryService = new UpdateInquiryService(inquiryRepository);
 
-        Inquiry inquiry1 = Inquiry.fake("inquiry1");
-        Inquiry inquiry2 = Inquiry.fake("inquiry2");
+        Inquiry inquiry1 = Fixture.inquiry("inquiry1");
+        Inquiry inquiry2 = Fixture.inquiry("inquiry2");
 
         given(inquiryRepository.save(any())).willReturn(inquiry1);
 

--- a/src/test/java/jinookk/ourlms/applications/lecture/CreateLectureServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/lecture/CreateLectureServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.lecture;
 
 import jinookk.ourlms.dtos.LectureDto;
 import jinookk.ourlms.dtos.LectureRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Lecture;
 import jinookk.ourlms.repositories.LectureRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class CreateLectureServiceTest {
         lectureRepository = mock(LectureRepository.class);
         createLectureService = new CreateLectureService(lectureRepository);
 
-        Lecture lecture = Lecture.fake("테스트 1강");
+        Lecture lecture = Fixture.lecture("테스트 1강");
 
         given(lectureRepository.findById(1L))
                 .willReturn(Optional.of(lecture));
@@ -38,7 +39,7 @@ class CreateLectureServiceTest {
 
     @Test
     void create() {
-        Lecture lecture = Lecture.fake("title");
+        Lecture lecture = Fixture.lecture("title");
 
         given(lectureRepository.save(any())).willReturn(lecture);
 

--- a/src/test/java/jinookk/ourlms/applications/lecture/DeleteLectureServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/lecture/DeleteLectureServiceTest.java
@@ -5,6 +5,7 @@ import jinookk.ourlms.dtos.LectureRequestDto;
 import jinookk.ourlms.dtos.LectureTimeDto;
 import jinookk.ourlms.dtos.LectureUpdateRequestDto;
 import jinookk.ourlms.dtos.LecturesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Lecture;
@@ -39,7 +40,7 @@ class DeleteLectureServiceTest {
         lectureRepository = mock(LectureRepository.class);
         deleteLectureService = new DeleteLectureService(lectureRepository);
 
-        Lecture lecture = Lecture.fake("테스트 1강");
+        Lecture lecture = Fixture.lecture("테스트 1강");
 
         given(lectureRepository.findById(1L))
                 .willReturn(Optional.of(lecture));

--- a/src/test/java/jinookk/ourlms/applications/lecture/GetLectureServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/lecture/GetLectureServiceTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.applications.lecture;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.dtos.LectureDto;
 import jinookk.ourlms.dtos.LecturesDto;
 import jinookk.ourlms.models.entities.Account;
@@ -25,7 +26,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class GetLectureServiceTest {
+class GetLectureServiceTest extends Fixture {
     GetLectureService getLectureService;
     LectureRepository lectureRepository;
     CourseRepository courseRepository;
@@ -40,7 +41,7 @@ class GetLectureServiceTest {
         lectureRepository = mock(LectureRepository.class);
         getLectureService = new GetLectureService(lectureRepository, courseRepository, paymentRepository, accountRepository);
 
-        Lecture lecture = Lecture.fake("테스트 1강");
+        Lecture lecture = Fixture.lecture("테스트 1강");
 
         given(lectureRepository.findById(1L))
                 .willReturn(Optional.of(lecture));
@@ -51,13 +52,13 @@ class GetLectureServiceTest {
         given(lectureRepository.findAllByCourseId(any()))
                 .willReturn(List.of(lecture));
 
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
         given(courseRepository.findAllByAccountId(new AccountId(1L))).willReturn(List.of(course));
 
-        Payment payment = Payment.fake(35000);
+        Payment payment = Fixture.payment(35000);
         given(paymentRepository.findAllByAccountId(any())).willReturn(List.of(payment));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/lecture/UpdateLectureServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/lecture/UpdateLectureServiceTest.java
@@ -3,6 +3,7 @@ package jinookk.ourlms.applications.lecture;
 import jinookk.ourlms.dtos.LectureDto;
 import jinookk.ourlms.dtos.LectureTimeDto;
 import jinookk.ourlms.dtos.LectureUpdateRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Lecture;
 import jinookk.ourlms.models.vos.LectureTime;
 import jinookk.ourlms.repositories.LectureRepository;
@@ -26,7 +27,7 @@ class UpdateLectureServiceTest {
         lectureRepository = mock(LectureRepository.class);
         updateLectureService = new UpdateLectureService(lectureRepository);
 
-        Lecture lecture = Lecture.fake("테스트 1강");
+        Lecture lecture = Fixture.lecture("테스트 1강");
 
         given(lectureRepository.findById(1L))
                 .willReturn(Optional.of(lecture));

--- a/src/test/java/jinookk/ourlms/applications/like/GetLikeServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/like/GetLikeServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.like;
 
 import jinookk.ourlms.dtos.LikeDto;
 import jinookk.ourlms.dtos.LikesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Like;
 import jinookk.ourlms.models.vos.UserName;
@@ -20,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetLikeServiceTest {
+class GetLikeServiceTest extends Fixture {
     GetLikeService getLikeService;
     LikeRepository likeRepository;
     AccountRepository accountRepository;
@@ -31,12 +32,12 @@ class GetLikeServiceTest {
         likeRepository = mock(LikeRepository.class);
         getLikeService = new GetLikeService(likeRepository, accountRepository);
 
-        Like like = Like.fake(false);
+        Like like = Fixture.like(false);
         given(likeRepository.findById(any())).willReturn(Optional.of(like));
         given(likeRepository.findByAccountIdAndCourseId(any(), any())).willReturn(Optional.of(like));
         given(likeRepository.findAll()).willReturn(List.of(like));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/like/UpdateLikeServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/like/UpdateLikeServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.like;
 
 import jinookk.ourlms.dtos.LikeDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Like;
 import jinookk.ourlms.models.vos.ids.LikeId;
 import jinookk.ourlms.repositories.LikeRepository;
@@ -24,7 +25,7 @@ class UpdateLikeServiceTest {
         likeRepository = mock(LikeRepository.class);
         likeService = new UpdateLikeService(likeRepository);
 
-        Like like = Like.fake(false);
+        Like like = Fixture.like(false);
         given(likeRepository.findById(any())).willReturn(Optional.of(like));
         given(likeRepository.findByAccountIdAndCourseId(any(), any())).willReturn(Optional.of(like));
         given(likeRepository.findAll()).willReturn(List.of(like));

--- a/src/test/java/jinookk/ourlms/applications/note/CreateNoteServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/note/CreateNoteServiceTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.applications.note;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.dtos.LectureTimeDto;
 import jinookk.ourlms.dtos.NoteDto;
 import jinookk.ourlms.dtos.NoteRequestDto;
@@ -22,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class CreateNoteServiceTest {
+class CreateNoteServiceTest extends Fixture {
     CreateNoteService createNoteService;
     NoteRepository noteRepository;
     AccountRepository accountRepository;
@@ -33,7 +34,7 @@ class CreateNoteServiceTest {
         noteRepository = mock(NoteRepository.class);
         createNoteService = new CreateNoteService(noteRepository, accountRepository);
 
-        Note note = Note.fake("content");
+        Note note = Fixture.note("content");
         given(noteRepository.save(any())).willReturn(note);
 
         given(noteRepository.findById(any())).willReturn(Optional.of(note));
@@ -41,7 +42,7 @@ class CreateNoteServiceTest {
         given(noteRepository.findAllByLectureIdAndAccountId(new LectureId(1L), new AccountId(1L)))
                 .willReturn(List.of(note));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/note/DeleteNoteServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/note/DeleteNoteServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.note;
 
 import jinookk.ourlms.dtos.NoteDeleteDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Note;
 import jinookk.ourlms.models.vos.ids.AccountId;
@@ -19,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class DeleteNoteServiceTest {
+class DeleteNoteServiceTest extends Fixture {
     DeleteNoteService deleteNoteService;
     NoteRepository noteRepository;
     AccountRepository accountRepository;
@@ -30,7 +31,7 @@ class DeleteNoteServiceTest {
         noteRepository = mock(NoteRepository.class);
         deleteNoteService = new DeleteNoteService(noteRepository);
 
-        Note note = Note.fake("content");
+        Note note = Fixture.note("content");
         given(noteRepository.save(any())).willReturn(note);
 
         given(noteRepository.findById(any())).willReturn(Optional.of(note));
@@ -38,7 +39,7 @@ class DeleteNoteServiceTest {
         given(noteRepository.findAllByLectureIdAndAccountId(new LectureId(1L), new AccountId(1L)))
                 .willReturn(List.of(note));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/note/GetNoteServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/note/GetNoteServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.note;
 
 import jinookk.ourlms.dtos.NotesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Note;
 import jinookk.ourlms.models.vos.UserName;
@@ -19,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetNoteServiceTest {
+class GetNoteServiceTest extends Fixture {
     GetNoteService getNoteService;
     NoteRepository noteRepository;
     AccountRepository accountRepository;
@@ -30,7 +31,7 @@ class GetNoteServiceTest {
         noteRepository = mock(NoteRepository.class);
         getNoteService = new GetNoteService(noteRepository, accountRepository);
 
-        Note note = Note.fake("content");
+        Note note = Fixture.note("content");
         given(noteRepository.save(any())).willReturn(note);
 
         given(noteRepository.findById(any())).willReturn(Optional.of(note));
@@ -38,7 +39,7 @@ class GetNoteServiceTest {
         given(noteRepository.findAllByLectureIdAndAccountId(new LectureId(1L), new AccountId(1L)))
                 .willReturn(List.of(note));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/note/UpdateNoteServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/note/UpdateNoteServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.note;
 
 import jinookk.ourlms.dtos.NoteDto;
 import jinookk.ourlms.dtos.NoteUpdateDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Note;
 import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.ids.LectureId;
@@ -27,7 +28,7 @@ class UpdateNoteServiceTest {
         noteRepository = mock(NoteRepository.class);
         updateNoteService = new UpdateNoteService(noteRepository);
 
-        Note note = Note.fake("content");
+        Note note = Fixture.note("content");
         given(noteRepository.save(any())).willReturn(note);
 
         given(noteRepository.findById(any())).willReturn(Optional.of(note));

--- a/src/test/java/jinookk/ourlms/applications/payment/CreatePaymentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/payment/CreatePaymentServiceTest.java
@@ -4,6 +4,7 @@ import jinookk.ourlms.applications.kakao.KakaoService;
 import jinookk.ourlms.dtos.MonthlyPaymentsDto;
 import jinookk.ourlms.dtos.PaymentRequestDto;
 import jinookk.ourlms.dtos.PaymentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Cart;
 import jinookk.ourlms.models.entities.Course;
@@ -37,7 +38,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class CreatePaymentServiceTest {
+class CreatePaymentServiceTest extends Fixture {
     CreatePaymentService createPaymentService;
     KakaoService kakaoService;
     PaymentRepository paymentRepository;
@@ -99,9 +100,9 @@ class CreatePaymentServiceTest {
 
 
         given(paymentRepository.findAllByAccountId(new AccountId(any())))
-                .willReturn(List.of(Payment.fake(24000), Payment.fake(35000), Payment.fake(49000)));
+                .willReturn(List.of(Fixture.payment(24000), Fixture.payment(35000), Fixture.payment(49000)));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 
@@ -110,22 +111,22 @@ class CreatePaymentServiceTest {
         PaymentRequestDto paymentRequestDto = new PaymentRequestDto("TOKEN");
         AccountId accountId = new AccountId(1L);
 
-        Course course = Course.fake("hi");
+        Course course = Fixture.course("hi");
 
         KakaoPayItemVO kakaoPayItemVO = new KakaoPayItemVO(List.of(course));
 
         given(kakaoService.approve(paymentRequestDto, accountId))
                 .willReturn(kakaoPayItemVO);
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
 
         given(accountRepository.findById(accountId.value()))
                 .willReturn(Optional.of(account));
 
-        Payment payment = Payment.fake(35000);
+        Payment payment = Fixture.payment(35000);
         given(paymentRepository.saveAll(any())).willReturn(List.of(payment));
 
-        Cart cart = Cart.fake(new AccountId(1L));
+        Cart cart = Fixture.cart(new AccountId(1L));
 
         cart = cart.addItem(course.id());
 

--- a/src/test/java/jinookk/ourlms/applications/payment/GetPaymentServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/payment/GetPaymentServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.payment;
 
 import jinookk.ourlms.dtos.MonthlyPaymentsDto;
 import jinookk.ourlms.dtos.PaymentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Payment;
@@ -30,7 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetPaymentServiceTest {
+class GetPaymentServiceTest extends Fixture{
     GetPaymentService getPaymentService;
     PaymentRepository paymentRepository;
     CourseRepository courseRepository;
@@ -82,9 +83,9 @@ class GetPaymentServiceTest {
 
 
         given(paymentRepository.findAllByAccountId(new AccountId(any())))
-                .willReturn(List.of(Payment.fake(24000), Payment.fake(35000), Payment.fake(49000)));
+                .willReturn(List.of(Fixture.payment(24000), Fixture.payment(35000), Fixture.payment(49000)));
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/progress/GetProgressServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/progress/GetProgressServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.progress;
 
 import jinookk.ourlms.dtos.ProgressDto;
 import jinookk.ourlms.dtos.ProgressesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Progress;
 import jinookk.ourlms.models.vos.UserName;
@@ -24,7 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetProgressServiceTest {
+class GetProgressServiceTest extends Fixture {
     ProgressRepository progressRepository;
     GetProgressService getProgressService;
     AccountRepository accountRepository;
@@ -35,7 +36,7 @@ class GetProgressServiceTest {
         progressRepository = mock(ProgressRepository.class);
         getProgressService = new GetProgressService(progressRepository, accountRepository);
 
-        Progress progress = Progress.fake("1강");
+        Progress progress = Fixture.progress("1강");
 
         given(progressRepository.findById(1L))
                 .willReturn(Optional.of(progress));
@@ -52,7 +53,7 @@ class GetProgressServiceTest {
         given(progressRepository.findAll((Specification<Progress>) any(), (Sort) any()))
                 .willReturn(List.of(progress));
 
-        Account account = Account.fake("userName@email.com");
+        Account account = Fixture.account("userName@email.com");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
     }
 

--- a/src/test/java/jinookk/ourlms/applications/progress/UpdateProgressServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/progress/UpdateProgressServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.progress;
 
 import jinookk.ourlms.dtos.LectureTimeDto;
 import jinookk.ourlms.dtos.ProgressDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Progress;
 import jinookk.ourlms.models.vos.LectureTime;
 import jinookk.ourlms.models.vos.ids.AccountId;
@@ -31,7 +32,7 @@ class UpdateProgressServiceTest {
         progressRepository = mock(ProgressRepository.class);
         updateProgressService = new UpdateProgressService(progressRepository);
 
-        Progress progress = Progress.fake("1강");
+        Progress progress = Fixture.progress("1강");
 
         given(progressRepository.findById(1L))
                 .willReturn(Optional.of(progress));

--- a/src/test/java/jinookk/ourlms/applications/rating/CreateRatingServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/rating/CreateRatingServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.rating;
 
 import jinookk.ourlms.dtos.RatingDto;
 import jinookk.ourlms.dtos.RatingRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Rating;
 import jinookk.ourlms.models.vos.Content;
@@ -21,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class CreateRatingServiceTest {
+class CreateRatingServiceTest extends Fixture {
     CreateRatingService createRatingService;
     RatingRepository ratingRepository;
     AccountRepository accountRepository;
@@ -32,7 +33,7 @@ class CreateRatingServiceTest {
         ratingRepository = mock(RatingRepository.class);
         createRatingService = new CreateRatingService(ratingRepository, accountRepository);
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
 
         Rating rating = new Rating(

--- a/src/test/java/jinookk/ourlms/applications/rating/GetRatingServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/rating/GetRatingServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.rating;
 
 import jinookk.ourlms.dtos.RatingDto;
 import jinookk.ourlms.dtos.RatingsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Account;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.entities.Rating;
@@ -24,7 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class GetRatingServiceTest {
+class GetRatingServiceTest extends Fixture {
     GetRatingService getRatingService;
     CourseRepository courseRepository;
     RatingRepository ratingRepository;
@@ -37,10 +38,10 @@ class GetRatingServiceTest {
         courseRepository = mock(CourseRepository.class);
         getRatingService = new GetRatingService(courseRepository, ratingRepository, accountRepository);
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
         given(accountRepository.findByUserName(any())).willReturn(Optional.of(account));
 
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
         given(courseRepository.findAllByAccountId(any()))
                 .willReturn(List.of(course));
 

--- a/src/test/java/jinookk/ourlms/applications/section/CreateSectionServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/section/CreateSectionServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.section;
 
 import jinookk.ourlms.dtos.SectionDto;
 import jinookk.ourlms.dtos.SectionRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Section;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.repositories.SectionRepository;
@@ -25,7 +26,7 @@ class CreateSectionServiceTest {
         sectionRepository = mock(SectionRepository.class);
         createSectionService = new CreateSectionService(sectionRepository);
 
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
         given(sectionRepository.findById(1L))
                 .willReturn(Optional.of(section));
@@ -39,7 +40,7 @@ class CreateSectionServiceTest {
 
     @Test
     void create() {
-        Section section = Section.fake("title");
+        Section section = Fixture.section("title");
 
         given(sectionRepository.save(any())).willReturn(section);
 

--- a/src/test/java/jinookk/ourlms/applications/section/DeleteSectionServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/section/DeleteSectionServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.section;
 
 import jinookk.ourlms.dtos.SectionDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Section;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.models.vos.status.Status;
@@ -24,7 +25,7 @@ class DeleteSectionServiceTest {
         sectionRepository = mock(SectionRepository.class);
         deleteSectionService = new DeleteSectionService(sectionRepository);
 
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
         given(sectionRepository.findById(1L))
                 .willReturn(Optional.of(section));

--- a/src/test/java/jinookk/ourlms/applications/section/GetSectionServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/section/GetSectionServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.section;
 
 import jinookk.ourlms.dtos.SectionsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Section;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.repositories.AccountRepository;
@@ -24,7 +25,7 @@ class GetSectionServiceTest {
         sectionRepository = mock(SectionRepository.class);
         getSectionService = new GetSectionService(sectionRepository);
 
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
         given(sectionRepository.findById(1L))
                 .willReturn(Optional.of(section));

--- a/src/test/java/jinookk/ourlms/applications/section/UpdateSectionServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/section/UpdateSectionServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.section;
 
 import jinookk.ourlms.dtos.SectionDto;
 import jinookk.ourlms.dtos.SectionUpdateRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Section;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import jinookk.ourlms.repositories.SectionRepository;
@@ -24,7 +25,7 @@ class UpdateSectionServiceTest {
         sectionRepository = mock(SectionRepository.class);
         updateSectionService = new UpdateSectionService(sectionRepository);
 
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
         given(sectionRepository.findById(1L))
                 .willReturn(Optional.of(section));

--- a/src/test/java/jinookk/ourlms/applications/skill/CreateSkillServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/skill/CreateSkillServiceTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.applications.skill;
 
 import jinookk.ourlms.dtos.SkillDto;
 import jinookk.ourlms.dtos.SkillRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Skill;
 import jinookk.ourlms.repositories.SkillRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class CreateSkillServiceTest {
 
     @Test
     void post() {
-        Skill skill = Skill.fake("skill");
+        Skill skill = Fixture.skill("skill");
 
         given(skillRepository.save(any())).willReturn(skill);
 

--- a/src/test/java/jinookk/ourlms/applications/skill/DeleteSkillServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/skill/DeleteSkillServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.skill;
 
 import jinookk.ourlms.dtos.SkillDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Skill;
 import jinookk.ourlms.repositories.SkillRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +26,7 @@ class DeleteSkillServiceTest {
 
     @Test
     void delete() {
-        Skill skill = Skill.fake("skill");
+        Skill skill = Fixture.skill("skill");
 
         given(skillRepository.findById(any())).willReturn(Optional.of(skill));
 

--- a/src/test/java/jinookk/ourlms/applications/skill/GetSkillServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/skill/GetSkillServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.skill;
 
 import jinookk.ourlms.dtos.SkillsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Skill;
 import jinookk.ourlms.repositories.SkillRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class GetSkillServiceTest {
 
     @Test
     void list() {
-        Skill skill = Skill.fake("skill");
+        Skill skill = Fixture.skill("skill");
 
         given(skillRepository.findAll()).willReturn(List.of(skill));
 

--- a/src/test/java/jinookk/ourlms/applications/token/IssueTokenServiceTest.java
+++ b/src/test/java/jinookk/ourlms/applications/token/IssueTokenServiceTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.applications.token;
 
 import jinookk.ourlms.applications.auth.IssueTokenService;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.RefreshToken;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.repositories.RefreshTokenRepository;
@@ -45,7 +46,7 @@ class IssueTokenServiceTest {
     @Test
     void reissueRefreshToken() {
         given(refreshTokenRepository.findByTokenValue(any()))
-                .willReturn(Optional.of(RefreshToken.fake("expired")));
+                .willReturn(Optional.of(Fixture.refreshToken("expired")));
 
         String userName = "tester@email.com";
 

--- a/src/test/java/jinookk/ourlms/controllers/CartControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/CartControllerTest.java
@@ -4,6 +4,7 @@ import jinookk.ourlms.applications.cart.AddCartItemService;
 import jinookk.ourlms.applications.cart.DeleteCartItemService;
 import jinookk.ourlms.applications.cart.GetCartService;
 import jinookk.ourlms.dtos.CartDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Cart;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.AccountId;
@@ -54,7 +55,7 @@ class CartControllerTest {
 
         List<CourseId> courseIds = List.of(new CourseId(1L), new CourseId(2L));
 
-        Cart cart = Cart.fake(new AccountId(1L));
+        Cart cart = Fixture.cart(new AccountId(1L));
 
         for (CourseId courseId : courseIds) {
             cart = cart.addItem(courseId.value());

--- a/src/test/java/jinookk/ourlms/controllers/CategoryControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/CategoryControllerTest.java
@@ -5,6 +5,7 @@ import jinookk.ourlms.applications.category.DeleteCategoryService;
 import jinookk.ourlms.applications.category.GetCategoryService;
 import jinookk.ourlms.dtos.CategoriesDto;
 import jinookk.ourlms.dtos.CategoryDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Category;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ class CategoryControllerTest {
 
     @Test
     void post() throws Exception {
-        CategoryDto categoryDto = Category.fake("category").toDto();
+        CategoryDto categoryDto = Fixture.category("category").toDto();
 
         given(createCategoryService.post(any())).willReturn(categoryDto);
 
@@ -55,7 +56,7 @@ class CategoryControllerTest {
 
     @Test
     void list() throws Exception {
-        CategoryDto categoryDto = Category.fake("category").toDto();
+        CategoryDto categoryDto = Fixture.category("category").toDto();
 
         given(getCategoryService.list()).willReturn(new CategoriesDto(List.of(categoryDto)));
 
@@ -68,7 +69,7 @@ class CategoryControllerTest {
 
     @Test
     void delete() throws Exception {
-        CategoryDto categoryDto = Category.fake("category").toDto();
+        CategoryDto categoryDto = Fixture.category("category").toDto();
 
         given(deleteCategoryService.delete(any())).willReturn(categoryDto);
 

--- a/src/test/java/jinookk/ourlms/controllers/CommentControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/CommentControllerTest.java
@@ -7,6 +7,7 @@ import jinookk.ourlms.applications.comment.UpdateCommentService;
 import jinookk.ourlms.dtos.CommentDeleteDto;
 import jinookk.ourlms.dtos.CommentDto;
 import jinookk.ourlms.dtos.CommentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Comment;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.InquiryId;
@@ -58,7 +59,7 @@ class CommentControllerTest {
 
     @Test
     void list() throws Exception {
-        CommentDto commentDto = Comment.fake("hi").toCommentDto();
+        CommentDto commentDto = Fixture.comment("hi").toCommentDto();
 
         CommentsDto commentsDto = new CommentsDto(List.of(commentDto));
         given(getCommentService.list(new InquiryId(1L), new UserName("userName@email.com"))).willReturn(commentsDto);
@@ -74,7 +75,7 @@ class CommentControllerTest {
 
     @Test
     void post() throws Exception {
-        CommentDto commentDto = Comment.fake("hi").toCommentDto();
+        CommentDto commentDto = Fixture.comment("hi").toCommentDto();
 
         given(createCommentService.create(any(), any())).willReturn(commentDto);
 
@@ -94,7 +95,7 @@ class CommentControllerTest {
 
     @Test
     void update() throws Exception {
-        CommentDto commentDto = Comment.fake("updated").toCommentDto();
+        CommentDto commentDto = Fixture.comment("updated").toCommentDto();
 
         given(updateCommentService.update(any(), any(), any())).willReturn(commentDto);
 
@@ -111,7 +112,7 @@ class CommentControllerTest {
 
     @Test
     void delete() throws Exception {
-        CommentDeleteDto commentDeleteDto = Comment.fake("hi").toCommentDeleteDto();
+        CommentDeleteDto commentDeleteDto = Fixture.comment("hi").toCommentDeleteDto();
         given(deleteCommentService.delete(any(), any())).willReturn(commentDeleteDto);
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/comments/11")

--- a/src/test/java/jinookk/ourlms/controllers/CourseControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/CourseControllerTest.java
@@ -7,6 +7,7 @@ import jinookk.ourlms.applications.course.UpdateCourseService;
 import jinookk.ourlms.applications.dtos.GetCoursesDto;
 import jinookk.ourlms.dtos.CourseDto;
 import jinookk.ourlms.dtos.CoursesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Course;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.applications.course.MyCourseService;
@@ -62,7 +63,7 @@ class CourseControllerTest {
 
     @Test
     void create() throws Exception {
-        CourseDto courseDto = Course.fake("courseTitle").toCourseDto();
+        CourseDto courseDto = Fixture.course("courseTitle").toCourseDto();
 
         given(createCourseService.create(any(), any())).willReturn(courseDto);
 
@@ -78,7 +79,7 @@ class CourseControllerTest {
 
     @Test
     void detail() throws Exception {
-        CourseDto courseDto = Course.fake("test").toCourseDto();
+        CourseDto courseDto = Fixture.course("test").toCourseDto();
 
         given(getCourseService.detail(any(), any())).willReturn(courseDto);
 
@@ -93,7 +94,7 @@ class CourseControllerTest {
 
     @Test
     void list() throws Exception {
-        CourseDto courseDto = Course.fake("test").toCourseDto();
+        CourseDto courseDto = Fixture.course("test").toCourseDto();
 
         given(getCourseService.list(anyInt(), any())).willReturn(new CoursesDto(List.of(courseDto), 1));
 
@@ -106,7 +107,7 @@ class CourseControllerTest {
 
     @Test
     void wishList() throws Exception {
-        CourseDto courseDto = Course.fake("test").toCourseDto();
+        CourseDto courseDto = Fixture.course("test").toCourseDto();
 
         given(getCourseService.wishList(any())).willReturn(new GetCoursesDto(List.of(courseDto)));
 
@@ -120,7 +121,7 @@ class CourseControllerTest {
 
     @Test
     void purchasedMyCourses() throws Exception {
-        CourseDto myCourseDto = Course.fake("my-courses").toCourseDto();
+        CourseDto myCourseDto = Fixture.course("my-courses").toCourseDto();
         List<CourseDto> dtos = List.of(myCourseDto);
 
         given(myCourseService.myCourses(any()))
@@ -136,7 +137,7 @@ class CourseControllerTest {
 
     @Test
     void update() throws Exception {
-        CourseDto courseDto = Course.fake("updated").toCourseDto();
+        CourseDto courseDto = Fixture.course("updated").toCourseDto();
 
         given(updateCourseService.update(any(), any(), any())).willReturn(courseDto);
 
@@ -161,7 +162,7 @@ class CourseControllerTest {
 
     @Test
     void updateStatus() throws Exception {
-        CourseDto courseDto = Course.fake("updated").toCourseDto();
+        CourseDto courseDto = Fixture.course("updated").toCourseDto();
 
         given(updateCourseService.updateStatus(any(), any())).willReturn(courseDto);
 
@@ -178,7 +179,7 @@ class CourseControllerTest {
 
     @Test
     void delete() throws Exception {
-        CourseDto courseDto = Course.fake(null).toCourseDto();
+        CourseDto courseDto = Fixture.course(null).toCourseDto();
 
         given(deleteCourseService.delete(any(), any())).willReturn(courseDto);
 
@@ -193,7 +194,7 @@ class CourseControllerTest {
 
     @Test
     void deleteSkill() throws Exception {
-        CourseDto courseDto = Course.fake(null).toCourseDto();
+        CourseDto courseDto = Fixture.course(null).toCourseDto();
 
         given(deleteCourseService.deleteSkill(any(), any(), any())).willReturn(courseDto);
 
@@ -208,7 +209,7 @@ class CourseControllerTest {
 
     @Test
     void uploadedMyCourses() throws Exception {
-        CourseDto courseDto = Course.fake("my-courses").toCourseDto();
+        CourseDto courseDto = Fixture.course("my-courses").toCourseDto();
         List<CourseDto> dtos = List.of(courseDto);
 
         given(myCourseService.uploadedList(any(), any()))

--- a/src/test/java/jinookk/ourlms/controllers/InquiryControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/InquiryControllerTest.java
@@ -7,6 +7,7 @@ import jinookk.ourlms.applications.inquiry.UpdateInquiryService;
 import jinookk.ourlms.dtos.InquiriesDto;
 import jinookk.ourlms.dtos.InquiryDeleteDto;
 import jinookk.ourlms.dtos.InquiryDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Inquiry;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.CourseId;
@@ -60,7 +61,7 @@ class InquiryControllerTest {
 
     @Test
     void inquiry() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         given(getInquiryService.detail(new InquiryId(1L))).willReturn(inquiryDto);
 
@@ -73,7 +74,7 @@ class InquiryControllerTest {
 
     @Test
     void list() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         InquiriesDto inquiriesDto = new InquiriesDto(List.of(inquiryDto));
         given(getInquiryService.list(new LectureId(1L), null, null)).willReturn(inquiriesDto);
@@ -87,7 +88,7 @@ class InquiryControllerTest {
 
     @Test
     void myInquiries() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         InquiriesDto inquiriesDto = new InquiriesDto(List.of(inquiryDto));
 
@@ -103,7 +104,7 @@ class InquiryControllerTest {
 
     @Test
     void listByCourseId() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         InquiriesDto inquiriesDto = new InquiriesDto(List.of(inquiryDto));
 
@@ -118,7 +119,7 @@ class InquiryControllerTest {
 
     @Test
     void post() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         given(createInquiryService.create(any(), any())).willReturn(inquiryDto);
 
@@ -141,7 +142,7 @@ class InquiryControllerTest {
 
     @Test
     void postWithBlankProperties() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         given(createInquiryService.create(any(), any())).willReturn(inquiryDto);
 
@@ -161,7 +162,7 @@ class InquiryControllerTest {
 
     @Test
     void update() throws Exception {
-        InquiryDto inquiryDto = Inquiry.fake("test").toInquiryDto();
+        InquiryDto inquiryDto = Fixture.inquiry("test").toInquiryDto();
 
         given(updateInquiryService.update(any(), any())).willReturn(inquiryDto);
 
@@ -179,7 +180,7 @@ class InquiryControllerTest {
 
     @Test
     void increaseHits() throws Exception {
-        Inquiry inquiry = Inquiry.fake("test");
+        Inquiry inquiry = Fixture.inquiry("test");
 
         Inquiry increased = inquiry.increaseHits();
 
@@ -195,7 +196,7 @@ class InquiryControllerTest {
 
     @Test
     void delete() throws Exception {
-        InquiryDeleteDto inquiryDto = Inquiry.fake("test").toInquiryDeleteDto();
+        InquiryDeleteDto inquiryDto = Fixture.inquiry("test").toInquiryDeleteDto();
 
         given(deleteInquiryService.delete(any())).willReturn(inquiryDto);
 

--- a/src/test/java/jinookk/ourlms/controllers/LectureControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/LectureControllerTest.java
@@ -6,6 +6,7 @@ import jinookk.ourlms.applications.lecture.GetLectureService;
 import jinookk.ourlms.applications.lecture.UpdateLectureService;
 import jinookk.ourlms.dtos.LectureDto;
 import jinookk.ourlms.dtos.LecturesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Lecture;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.CourseId;
@@ -57,7 +58,7 @@ class LectureControllerTest {
 
     @Test
     void create() throws Exception {
-        LectureDto lectureDto = Lecture.fake("hi").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("hi").toLectureDto();
 
         given(createLectureService.create(any()))
                 .willReturn(lectureDto);
@@ -77,7 +78,7 @@ class LectureControllerTest {
 
     @Test
     void lecture() throws Exception {
-        LectureDto lectureDto = Lecture.fake("test lecture 1").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("test lecture 1").toLectureDto();
 
         given(getLectureService.detail(1L))
                 .willReturn(lectureDto);
@@ -91,7 +92,7 @@ class LectureControllerTest {
 
     @Test
     void listByCourseId() throws Exception {
-        LectureDto lectureDto = Lecture.fake("test lecture 1").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("test lecture 1").toLectureDto();
 
         LecturesDto lecturesDto = new LecturesDto(List.of(lectureDto));
 
@@ -107,7 +108,7 @@ class LectureControllerTest {
 
     @Test
     void list() throws Exception {
-        LectureDto lectureDto = Lecture.fake("test lecture 1").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("test lecture 1").toLectureDto();
 
         LecturesDto lecturesDto = new LecturesDto(List.of(lectureDto));
 
@@ -123,7 +124,7 @@ class LectureControllerTest {
 
     @Test
     void listByInstructorId() throws Exception {
-        LectureDto lectureDto = Lecture.fake("test lecture 1").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("test lecture 1").toLectureDto();
 
         LecturesDto lecturesDto = new LecturesDto(List.of(lectureDto));
 
@@ -140,7 +141,7 @@ class LectureControllerTest {
 
     @Test
     void myLectures() throws Exception {
-        LectureDto lectureDto = Lecture.fake("test lecture 1").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("test lecture 1").toLectureDto();
 
         LecturesDto lecturesDto = new LecturesDto(List.of(lectureDto));
 
@@ -157,7 +158,7 @@ class LectureControllerTest {
 
     @Test
     void update() throws Exception {
-        LectureDto lectureDto = Lecture.fake("updated").toLectureDto();
+        LectureDto lectureDto = Fixture.lecture("updated").toLectureDto();
 
         given(updateLectureService.update(any(), any()))
                 .willReturn(lectureDto);
@@ -178,7 +179,7 @@ class LectureControllerTest {
 
     @Test
     void delete() throws Exception {
-        LectureDto lectureDto = Lecture.fake((String) null).toLectureDto();
+        LectureDto lectureDto = Fixture.lecture((String) null).toLectureDto();
 
         given(deleteLectureService.delete(any()))
                 .willReturn(lectureDto);

--- a/src/test/java/jinookk/ourlms/controllers/LikeControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/LikeControllerTest.java
@@ -3,6 +3,7 @@ package jinookk.ourlms.controllers;
 import jinookk.ourlms.applications.like.GetLikeService;
 import jinookk.ourlms.dtos.LikeDto;
 import jinookk.ourlms.dtos.LikesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Like;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.applications.like.UpdateLikeService;
@@ -47,7 +48,7 @@ class LikeControllerTest {
 
     @Test
     void list() throws Exception {
-        LikeDto likeDto = Like.fake(true).toDto();
+        LikeDto likeDto = Fixture.like(true).toDto();
 
         given(getLikeService.list()).willReturn(new LikesDto(List.of(likeDto)));
 
@@ -60,7 +61,7 @@ class LikeControllerTest {
 
     @Test
     void like() throws Exception {
-        LikeDto likeDto = Like.fake(true).toDto();
+        LikeDto likeDto = Fixture.like(true).toDto();
 
         given(getLikeService.detail(any(), any())).willReturn(likeDto);
 
@@ -74,7 +75,7 @@ class LikeControllerTest {
 
     @Test
     void toggle() throws Exception {
-        LikeDto likeDto = Like.fake(false).toDto();
+        LikeDto likeDto = Fixture.like(false).toDto();
 
         given(updateLikeService.toggle(any())).willReturn(likeDto);
 

--- a/src/test/java/jinookk/ourlms/controllers/NoteControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/NoteControllerTest.java
@@ -7,6 +7,7 @@ import jinookk.ourlms.applications.note.UpdateNoteService;
 import jinookk.ourlms.dtos.NoteDeleteDto;
 import jinookk.ourlms.dtos.NoteDto;
 import jinookk.ourlms.dtos.NotesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Note;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.models.vos.ids.NoteId;
@@ -58,7 +59,7 @@ class NoteControllerTest {
 
     @Test
     void post() throws Exception {
-        NoteDto noteDto = Note.fake("hi").toNoteDto();
+        NoteDto noteDto = Fixture.note("hi").toNoteDto();
         given(createNoteService.create(any(), any())).willReturn(noteDto);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/notes")
@@ -80,7 +81,7 @@ class NoteControllerTest {
     }
     @Test
     void list() throws Exception {
-        NoteDto noteDto = Note.fake("hi").toNoteDto();
+        NoteDto noteDto = Fixture.note("hi").toNoteDto();
         given(getNoteService.list(any(), any())).willReturn(new NotesDto(List.of(noteDto)));
 
         mockMvc.perform(MockMvcRequestBuilders.get("/lectures/1/notes")
@@ -93,7 +94,7 @@ class NoteControllerTest {
 
     @Test
     void update() throws Exception {
-        NoteDto noteDto = Note.fake("updated").toNoteDto();
+        NoteDto noteDto = Fixture.note("updated").toNoteDto();
         given(updateNoteService.update(any(), any())).willReturn(noteDto);
 
         mockMvc.perform(MockMvcRequestBuilders.patch("/notes/1")

--- a/src/test/java/jinookk/ourlms/controllers/PaymentControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/PaymentControllerTest.java
@@ -8,6 +8,7 @@ import jinookk.ourlms.dtos.MonthlyPaymentDto;
 import jinookk.ourlms.dtos.MonthlyPaymentsDto;
 import jinookk.ourlms.dtos.PaymentDto;
 import jinookk.ourlms.dtos.PaymentsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Payment;
 import jinookk.ourlms.models.vos.Title;
 import jinookk.ourlms.models.vos.UserName;
@@ -74,7 +75,7 @@ class PaymentControllerTest {
 
     @Test
     void purchase() throws Exception {
-        PaymentDto paymentDto = Payment.fake(35_000).toDto();
+        PaymentDto paymentDto = Fixture.payment(35_000).toDto();
 
         given(createPaymentService.purchase(any(), any()))
                 .willReturn(new PaymentsDto(List.of(paymentDto)));
@@ -93,7 +94,7 @@ class PaymentControllerTest {
 
     @Test
     void list() throws Exception {
-        PaymentDto paymentDto = Payment.fake(35_000).toDto();
+        PaymentDto paymentDto = Fixture.payment(35_000).toDto();
 
         given(getPaymentService.list(new UserName("userName@email.com"), new CourseId(1L)))
                 .willReturn(new PaymentsDto(List.of(paymentDto)));
@@ -108,7 +109,7 @@ class PaymentControllerTest {
 
     @Test
     void myPayments() throws Exception {
-        PaymentDto paymentDto = Payment.fake(35_000).toDto();
+        PaymentDto paymentDto = Fixture.payment(35_000).toDto();
 
         given(getPaymentService.list(new UserName("userName@email.com")))
                 .willReturn(new PaymentsDto(List.of(paymentDto)));

--- a/src/test/java/jinookk/ourlms/controllers/ProgressControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/ProgressControllerTest.java
@@ -4,6 +4,7 @@ import jinookk.ourlms.applications.progress.GetProgressService;
 import jinookk.ourlms.applications.progress.UpdateProgressService;
 import jinookk.ourlms.dtos.ProgressDto;
 import jinookk.ourlms.dtos.ProgressesDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Progress;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.utils.JwtUtil;
@@ -48,7 +49,7 @@ class ProgressControllerTest {
 
     @Test
     void progress() throws Exception {
-        ProgressDto progressDto = Progress.fake("테스트 1강").toDto();
+        ProgressDto progressDto = Fixture.progress("테스트 1강").toDto();
 
         given(getProgressService.detail(any(), any())).willReturn(progressDto);
 
@@ -62,7 +63,7 @@ class ProgressControllerTest {
 
     @Test
     void list() throws Exception {
-        ProgressDto progressDto = Progress.fake("테스트 1강").toDto();
+        ProgressDto progressDto = Fixture.progress("테스트 1강").toDto();
 
         ProgressesDto progressesDto = new ProgressesDto(List.of(progressDto));
         given(getProgressService.list(any(), any())).willReturn(progressesDto);
@@ -77,7 +78,7 @@ class ProgressControllerTest {
 
     @Test
     void listByCourseId() throws Exception {
-        ProgressDto progressDto = Progress.fake("테스트 1강").toDto();
+        ProgressDto progressDto = Fixture.progress("테스트 1강").toDto();
 
         ProgressesDto progressesDto = new ProgressesDto(List.of(progressDto));
         given(getProgressService.listByCourseId(any())).willReturn(progressesDto);
@@ -91,7 +92,7 @@ class ProgressControllerTest {
 
     @Test
     void complete() throws Exception {
-        Progress progress = Progress.fake("테스트 1강");
+        Progress progress = Fixture.progress("테스트 1강");
         progress.complete();
 
         ProgressDto progressDto = progress.toDto();
@@ -107,7 +108,7 @@ class ProgressControllerTest {
 
     @Test
     void updateTime() throws Exception {
-        Progress progress = Progress.fake("테스트 1강");
+        Progress progress = Fixture.progress("테스트 1강");
 
         ProgressDto progressDto = progress.toDto();
 

--- a/src/test/java/jinookk/ourlms/controllers/SectionControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/SectionControllerTest.java
@@ -6,6 +6,7 @@ import jinookk.ourlms.applications.section.GetSectionService;
 import jinookk.ourlms.applications.section.UpdateSectionService;
 import jinookk.ourlms.dtos.SectionDto;
 import jinookk.ourlms.dtos.SectionsDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Section;
 import jinookk.ourlms.models.vos.UserName;
 import jinookk.ourlms.utils.JwtUtil;
@@ -56,7 +57,7 @@ class SectionControllerTest {
 
     @Test
     void create() throws Exception {
-        SectionDto sectionDto = Section.fake("hi").toSectionDto();
+        SectionDto sectionDto = Fixture.section("hi").toSectionDto();
 
         given(createSectionService.create(any()))
                 .willReturn(sectionDto);
@@ -76,7 +77,7 @@ class SectionControllerTest {
 
     @Test
     void list() throws Exception {
-        SectionDto sectionDto = Section.fake("hi").toSectionDto();
+        SectionDto sectionDto = Fixture.section("hi").toSectionDto();
 
         given(getSectionService.list())
                 .willReturn(new SectionsDto(List.of(sectionDto)));
@@ -108,7 +109,7 @@ class SectionControllerTest {
 
     @Test
     void update() throws Exception {
-        SectionDto sectionDto = Section.fake("updated").toSectionDto();
+        SectionDto sectionDto = Fixture.section("updated").toSectionDto();
 
         given(updateSectionService.update(any(), any()))
                 .willReturn(sectionDto);
@@ -127,7 +128,7 @@ class SectionControllerTest {
 
     @Test
     void delete() throws Exception {
-        SectionDto sectionDto = Section.fake(null).toSectionDto();
+        SectionDto sectionDto = Fixture.section(null).toSectionDto();
 
         given(deleteSectionService.delete(any()))
                 .willReturn(sectionDto);

--- a/src/test/java/jinookk/ourlms/controllers/SkillControllerTest.java
+++ b/src/test/java/jinookk/ourlms/controllers/SkillControllerTest.java
@@ -5,6 +5,7 @@ import jinookk.ourlms.applications.skill.DeleteSkillService;
 import jinookk.ourlms.applications.skill.GetSkillService;
 import jinookk.ourlms.dtos.SkillsDto;
 import jinookk.ourlms.dtos.SkillDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.entities.Skill;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ class SkillControllerTest {
 
     @Test
     void post() throws Exception {
-        SkillDto skillDto = Skill.fake("skill").toDto();
+        SkillDto skillDto = Fixture.skill("skill").toDto();
 
         given(createSkillService.post(any())).willReturn(skillDto);
 
@@ -55,7 +56,7 @@ class SkillControllerTest {
 
     @Test
     void list() throws Exception {
-        SkillDto skillDto = Skill.fake("skill").toDto();
+        SkillDto skillDto = Fixture.skill("skill").toDto();
 
         given(getSkillService.list()).willReturn(new SkillsDto(List.of(skillDto)));
 
@@ -68,7 +69,7 @@ class SkillControllerTest {
 
     @Test
     void delete() throws Exception {
-        SkillDto skillDto = Skill.fake("skill").toDto();
+        SkillDto skillDto = Fixture.skill("skill").toDto();
 
         given(deleteSkillService.delete(any())).willReturn(skillDto);
 

--- a/src/test/java/jinookk/ourlms/fixtures/Fixture.java
+++ b/src/test/java/jinookk/ourlms/fixtures/Fixture.java
@@ -1,0 +1,137 @@
+package jinookk.ourlms.fixtures;
+
+import jinookk.ourlms.models.entities.Account;
+import jinookk.ourlms.models.entities.Cart;
+import jinookk.ourlms.models.entities.Category;
+import jinookk.ourlms.models.entities.Comment;
+import jinookk.ourlms.models.entities.Course;
+import jinookk.ourlms.models.entities.Inquiry;
+import jinookk.ourlms.models.entities.Lecture;
+import jinookk.ourlms.models.entities.Like;
+import jinookk.ourlms.models.entities.Note;
+import jinookk.ourlms.models.entities.Payment;
+import jinookk.ourlms.models.entities.Progress;
+import jinookk.ourlms.models.entities.Rating;
+import jinookk.ourlms.models.entities.RefreshToken;
+import jinookk.ourlms.models.entities.Section;
+import jinookk.ourlms.models.entities.Skill;
+import jinookk.ourlms.models.vos.Content;
+import jinookk.ourlms.models.vos.HandOutUrl;
+import jinookk.ourlms.models.vos.ImagePath;
+import jinookk.ourlms.models.vos.LectureTime;
+import jinookk.ourlms.models.vos.Name;
+import jinookk.ourlms.models.vos.Price;
+import jinookk.ourlms.models.vos.Title;
+import jinookk.ourlms.models.vos.UserName;
+import jinookk.ourlms.models.vos.VideoUrl;
+import jinookk.ourlms.models.vos.ids.AccountId;
+import jinookk.ourlms.models.vos.ids.CourseId;
+import jinookk.ourlms.models.vos.ids.InquiryId;
+import jinookk.ourlms.models.vos.ids.LectureId;
+import jinookk.ourlms.models.vos.ids.SectionId;
+import jinookk.ourlms.models.vos.status.Status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class Fixture {
+    protected static Account account(String name) {
+        UserName userName = new UserName("ojw0828@naver.com");
+        Long id = 1L;
+
+        return new Account(id, new Name(name, false), userName);
+    }
+
+    public static Cart cart(AccountId accountId) {
+        return new Cart(accountId);
+    }
+
+    public static Category category(String content) {
+        return new Category(new Content(content), "url");
+    }
+
+    public static Comment comment(String content) {
+        return new Comment(11L, new InquiryId(1L), new AccountId(1L), new Status(Status.CREATED),
+                new Name("1st Tester", false), new Content(content), LocalDateTime.now());
+    }
+
+    public static Course course(String title) {
+        Long id = 1L;
+        ImagePath imagePath = new ImagePath("imagePath");
+        jinookk.ourlms.models.vos.Category category = new jinookk.ourlms.models.vos.Category("category");
+        Name instructor = new Name("instructor", false);
+        AccountId accountId = new AccountId(1L);
+        Content description = new Content("description");
+        Price price = new Price(10000);
+        Status status = new Status(Status.PROCESSING);
+
+        return new Course(id, new Title(title), description, status, imagePath, category, instructor, accountId, price);
+    }
+
+    public static Inquiry inquiry(String content) {
+        return new Inquiry(1L, new CourseId(1L), new LectureId(1L), new AccountId(1L), List.of(), new Title("title"), new Content(content),
+                new LectureTime(1, 24), new Name("tester", false), false, LocalDateTime.now(), LocalDateTime.now());
+    }
+
+    public static Inquiry inquiry(Name publisher) {
+        return new Inquiry(1L, new CourseId(1L), new LectureId(1L), new AccountId(1L), List.of(), new Title("title"),
+                new Content("hi"), new LectureTime(1, 24), publisher, false, LocalDateTime.now(), LocalDateTime.now());
+    }
+
+    public static Lecture lecture(String lectureTitle) {
+        Long id = 1L;
+        CourseId courseId = new CourseId(1L);
+        Content lectureNote = new Content("lectureNote");
+        SectionId sectionId = new SectionId(1L);
+        HandOutUrl handOutUrl = new HandOutUrl("url");
+        VideoUrl videoUrl = new VideoUrl("video/url");
+
+        return new Lecture(id, courseId, sectionId, new Title(lectureTitle), lectureNote, handOutUrl, videoUrl);
+    }
+
+    public static Lecture lecture(LectureId lectureId) {
+        Long id = lectureId.value();
+        CourseId courseId = new CourseId(1L);
+        Content lectureNote = new Content("lectureNote");
+        SectionId sectionId = new SectionId(1L);
+        Title title = new Title("title");
+        HandOutUrl handOutUrl = new HandOutUrl("url");
+        VideoUrl videoUrl = new VideoUrl("video/url");
+
+        return new Lecture(id, courseId, sectionId, title, lectureNote, handOutUrl, videoUrl);
+    }
+
+    public static Like like(Boolean clicked) {
+        return new Like(new AccountId(1L), new CourseId(1L), clicked);
+    }
+
+    public static Note note(String content) {
+        return new Note(1L, new LectureId(1L), new AccountId(1L), new Status(Status.CREATED), new Content(content),
+                new LectureTime(1, 24), LocalDateTime.now());
+    }
+
+    public static Payment payment(int price) {
+        return new Payment(1L, new CourseId(1L), new AccountId(1L), new Price(price), new Title("course title"),
+                new Name("purchaser", false), LocalDateTime.now());
+    }
+
+    public static Progress progress(String lectureTitle) {
+        return new Progress(31L, new CourseId(1L), new AccountId(1L), new LectureId(1L), new Title(lectureTitle));
+    }
+
+    public static Rating rating(Double point) {
+        return new Rating(1L, new AccountId(1L), new CourseId(1L), new Name("author", false), new Content("content"), point);
+    }
+
+    public static RefreshToken refreshToken(String expired) {
+        return new RefreshToken("tester@email.com", expired);
+    }
+
+    public static Section section(String title) {
+        return new Section(1L, new CourseId(1L), new Status(Status.CREATED), new Title(title), new Content("goal"));
+    }
+
+    public static Skill skill(String skill) {
+        return new Skill(skill);
+    }
+}

--- a/src/test/java/jinookk/ourlms/models/CourseTest.java
+++ b/src/test/java/jinookk/ourlms/models/CourseTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.models;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.dtos.CourseDto;
 import jinookk.ourlms.dtos.MonthlyPaymentDto;
 import jinookk.ourlms.dtos.MyCourseDto;
@@ -24,10 +25,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CourseTest {
+class CourseTest extends Fixture {
     @Test
     void convertToMyCourseDto() {
-        Course course = Course.fake("Test");
+        Course course = Fixture.course("Test");
 
         MyCourseDto myCourseDto = course.toMyCourseDto();
 
@@ -36,7 +37,7 @@ class CourseTest {
 
     @Test
     void averageRating() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         List<Rating> ratings = List.of(
                 new Rating(1L, new AccountId(1L), new CourseId(1L), new Name("name1", false), new Content("content1"), 4.0),
@@ -51,7 +52,7 @@ class CourseTest {
 
     @Test
     void averageRatingWithBlankList() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         List<Rating> ratings = List.of();
         Double rating = course.averageRating(ratings);
@@ -61,7 +62,7 @@ class CourseTest {
 
     @Test
     void convertToMonthlyPaymentDto() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         List<Payment> payments = List.of(
                 new Payment(1L, new CourseId(1L), new AccountId(1L), new Price(35_000),
@@ -79,7 +80,7 @@ class CourseTest {
 
     @Test
     void convertToMonthlyPaymentDtoWithOverdated() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         List<Payment> payments = List.of(
                 new Payment(4L, new CourseId(1L), new AccountId(3L), new Price(35_000),
@@ -95,7 +96,7 @@ class CourseTest {
 
     @Test
     void convertToMonthlyPaymentDtoWithBlankList() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         List<Payment> payments = List.of();
 
@@ -106,30 +107,30 @@ class CourseTest {
 
     @Test
     void filterIdWithNullValue() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.filterId(new CourseId(null))).isTrue();
     }
 
     @Test
     void filterIdWithCorrectValue() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.filterId(new CourseId(1L))).isTrue();
     }
 
     @Test
     void filterIdWithIncorrectValue() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.filterId(new CourseId(10L))).isFalse();
     }
 
     @Test
     void validatePayment() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
-        Payment payment = Payment.fake(35_000);
+        Payment payment = Fixture.payment(35_000);
 
         boolean validatePayment = course.validatePayment(Optional.of(payment));
 
@@ -138,7 +139,7 @@ class CourseTest {
 
     @Test
     void validatePaymentWithNull() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         boolean validatePayment = course.validatePayment(Optional.empty());
 
@@ -147,7 +148,7 @@ class CourseTest {
 
     @Test
     void validateInstructor() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         boolean validateInstructor = course.isInstructor(new AccountId(1L));
 
@@ -156,7 +157,7 @@ class CourseTest {
 
     @Test
     void validateInstructorWithIncorrectId() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.isInstructor(new AccountId(2L))).isFalse();
         assertThat(course.isInstructor(new AccountId(null))).isFalse();
@@ -165,9 +166,9 @@ class CourseTest {
 
     @Test
     void convertToDtoWithPayment() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
-        Account account = Account.fake("account");
+        Account account = Fixture.account("account");
 
         CourseDto courseDto = course.toCourseDto(Optional.of(account));
 
@@ -176,7 +177,7 @@ class CourseTest {
 
     @Test
     void convertToDtoWithPaymentNull() {
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         CourseDto courseDto = course.toCourseDto(Optional.empty());
 
@@ -185,7 +186,7 @@ class CourseTest {
 
     @Test
     void fake() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.level()).isEqualTo(Level.TOBEDETERMINED);
         assertThat(course.imagePath()).isEqualTo(new ImagePath("imagePath"));
@@ -193,7 +194,7 @@ class CourseTest {
 
     @Test
     void changeLevel() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.level()).isEqualTo(Level.TOBEDETERMINED);
 
@@ -204,7 +205,7 @@ class CourseTest {
 
     @Test
     void updateStatus() {
-        Course course = Course.fake("fake");
+        Course course = Fixture.course("fake");
 
         assertThat(course.status().value()).isEqualTo("processing");
 

--- a/src/test/java/jinookk/ourlms/models/entities/CommentTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/CommentTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.models.entities;
 
 import jinookk.ourlms.dtos.CommentRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.vos.Content;
 import jinookk.ourlms.models.vos.HashTag;
 import jinookk.ourlms.models.vos.LectureTime;
@@ -46,7 +47,7 @@ class CommentTest {
 
     @Test
     void removeAllProperties() {
-        Comment comment = Comment.fake("hi");
+        Comment comment = Fixture.comment("hi");
 
         comment.removeAllProperties(new AccountId(1L));
 
@@ -57,7 +58,7 @@ class CommentTest {
 
     @Test
     void isMyComment() {
-        Comment comment = Comment.fake("hi");
+        Comment comment = Fixture.comment("hi");
 
         assertThat(comment.accountId()).isEqualTo(new AccountId(1L));
 
@@ -69,8 +70,8 @@ class CommentTest {
     void createCommentWithSameAccountIdWithInquiry() {
         Account account = new Account(new Name("tester", false), new UserName("userName@email.com"));
         CommentRequestDto commentRequestDto = new CommentRequestDto(new InquiryId(1L), "comment");
-        List<Comment> comments = List.of(Comment.fake("hi"));
-        Course course = Course.fake("course");
+        List<Comment> comments = List.of(Fixture.comment("hi"));
+        Course course = Fixture.course("course");
 
         Comment comment = Comment.of(inquiry, comments, commentRequestDto, account, course);
 
@@ -83,9 +84,9 @@ class CommentTest {
         Account account = new Account(new Name("tester", false), new UserName("userName@email.com"));
         CommentRequestDto commentRequestDto = new CommentRequestDto(new InquiryId(1L), "comment");
 
-        Comment commentWithFirstAccountId = Comment.fake("hi");
+        Comment commentWithFirstAccountId = Fixture.comment("hi");
         List<Comment> comments = List.of(commentWithFirstAccountId);
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         Comment comment = Comment.of(inquiry, comments, commentRequestDto, account, course);
 
@@ -102,7 +103,7 @@ class CommentTest {
                 new Name("3rd Author", false), new Content("content"), LocalDateTime.now());
 
         List<Comment> comments = List.of(commentWithThirdAccountId);
-        Course course = Course.fake("course");
+        Course course = Fixture.course("course");
 
         Comment comment = Comment.of(inquiry, comments, commentRequestDto, account, course);
 

--- a/src/test/java/jinookk/ourlms/models/entities/InquiryTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/InquiryTest.java
@@ -1,6 +1,7 @@
 package jinookk.ourlms.models.entities;
 
 import jinookk.ourlms.dtos.InquiryRequestDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.Content;
 import jinookk.ourlms.models.vos.HashTag;
@@ -70,7 +71,7 @@ class InquiryTest {
     void validatePreviousCommentWithDifferentAccountId() {
         AccountId accountId = new AccountId(3L);
 
-        List<Comment> comments = List.of(Comment.fake("hi"));
+        List<Comment> comments = List.of(Fixture.comment("hi"));
 
         Optional<Comment> comment = inquiry.previousComment(comments, accountId);
 
@@ -79,7 +80,7 @@ class InquiryTest {
 
     @Test
     void toggleSolved() {
-        Inquiry inquiry = Inquiry.fake("fake");
+        Inquiry inquiry = Fixture.inquiry("fake");
 
         assertThat(inquiry.status().solved()).isEqualTo("processing");
 
@@ -90,7 +91,7 @@ class InquiryTest {
 
     @Test
     void reply() {
-        Inquiry inquiry = Inquiry.fake("fake");
+        Inquiry inquiry = Fixture.inquiry("fake");
 
         assertThat(inquiry.status().replied()).isEqualTo("processing");
 
@@ -101,7 +102,7 @@ class InquiryTest {
 
     @Test
     void increaseHits() {
-        Inquiry fake = Inquiry.fake("fake");
+        Inquiry fake = Fixture.inquiry("fake");
 
         assertThat(fake.hits()).isEqualTo(0);
 

--- a/src/test/java/jinookk/ourlms/models/entities/LikeTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/LikeTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.models.entities;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.vos.ids.AccountId;
 import jinookk.ourlms.models.vos.ids.CourseId;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LikeTest {
     @Test
     void toggle() {
-        Like like = Like.fake(false);
+        Like like = Fixture.like(false);
 
         assertThat(like.clicked()).isEqualTo(false);
 

--- a/src/test/java/jinookk/ourlms/models/entities/PaymentTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/PaymentTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.models.entities;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.exceptions.InvalidPaymentInformation;
 import jinookk.ourlms.models.vos.Name;
 import jinookk.ourlms.models.vos.ids.AccountId;
@@ -11,20 +12,20 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class PaymentTest {
+class PaymentTest extends Fixture {
     private Cart cart;
 
     @BeforeEach
     void setup() {
-        cart = Cart.fake(new AccountId(1L));
+        cart = Fixture.cart(new AccountId(1L));
 
         cart = cart.addItem(1L);
     }
 
     @Test
     void create() {
-        Course course = Course.fake("fake");
-        Account account = Account.fake("tester");
+        Course course = Fixture.course("fake");
+        Account account = Fixture.account("tester");
 
         Payment payment = Payment.of(account, course);
 
@@ -36,26 +37,26 @@ class PaymentTest {
     @Test
     void createWithInvalidInformation() {
         assertThrows(InvalidPaymentInformation.class, () -> {
-            Payment.of(Account.fake("tester"), Course.fake(null));
+            Payment.of(Fixture.account("tester"), Fixture.course(null));
         });
 
         assertThrows(InvalidPaymentInformation.class, () -> {
-            Payment.of(Account.fake(null), Course.fake("fake"));
+            Payment.of(Fixture.account(null), Fixture.course("fake"));
         });
 
         assertThrows(InvalidPaymentInformation.class, () -> {
-            Payment.of(Account.fake("tester"), null);
+            Payment.of(Fixture.account("tester"), null);
         });
 
         assertThrows(InvalidPaymentInformation.class, () -> {
-            Payment.of(null, Course.fake("fake"));
+            Payment.of(null, Fixture.course("fake"));
         });
     }
 
     @Test
     void createList() {
-        Course course = Course.fake("fake");
-        Account account = Account.fake("tester");
+        Course course = Fixture.course("fake");
+        Account account = Fixture.account("tester");
 
         List<Course> courses = List.of(course);
 
@@ -66,8 +67,8 @@ class PaymentTest {
 
     @Test
     void createListWithInvalidValue() {
-        Course course = Course.fake("fake");
-        Account account = Account.fake("tester");
+        Course course = Fixture.course("fake");
+        Account account = Fixture.account("tester");
 
         assertThrows(InvalidPaymentInformation.class, () -> {
             Payment.listOf(List.of(), account, cart);

--- a/src/test/java/jinookk/ourlms/models/entities/ProgressTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/ProgressTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.models.entities;
 
 import jinookk.ourlms.dtos.LectureTimeDto;
 import jinookk.ourlms.exceptions.InvalidArgument;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.vos.LectureTime;
 import jinookk.ourlms.models.vos.Title;
 import jinookk.ourlms.models.vos.ids.AccountId;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ProgressTest {
     @Test
     void complete() {
-        Progress progress = Progress.fake("test");
+        Progress progress = Fixture.progress("test");
 
         assertThat(progress.status().value()).isEqualTo("processing");
 
@@ -29,7 +30,7 @@ class ProgressTest {
 
     @Test
     void updateTime() {
-        Progress progress = Progress.fake("test");
+        Progress progress = Fixture.progress("test");
 
         Progress updated = progress.updateTime(new LectureTimeDto(new LectureTime(5, 30)));
 
@@ -38,7 +39,7 @@ class ProgressTest {
 
     @Test
     void createdFromLecture() {
-        Lecture lecture = Lecture.fake(new LectureId(1L));
+        Lecture lecture = Fixture.lecture(new LectureId(1L));
 
         AccountId accountId = new AccountId(1L);
 
@@ -58,14 +59,14 @@ class ProgressTest {
         });
 
         assertThrows(InvalidArgument.class, () -> {
-            Progress.of(Lecture.fake(new LectureId(1L)), null);
+            Progress.of(Fixture.lecture(new LectureId(1L)), null);
         });
     }
 
     @Test
     void collectionWithValidLectures() {
         List<Lecture> lectures = List.of(
-                Lecture.fake(new LectureId(1L)), Lecture.fake(new LectureId(2L)), Lecture.fake(new LectureId(3L)));
+                Fixture.lecture(new LectureId(1L)), Fixture.lecture(new LectureId(2L)), Fixture.lecture(new LectureId(3L)));
 
         AccountId accountId = new AccountId(1L);
 

--- a/src/test/java/jinookk/ourlms/models/entities/RatingTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/RatingTest.java
@@ -1,5 +1,6 @@
 package jinookk.ourlms.models.entities;
 
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.dtos.RatingRequestDto;
 import jinookk.ourlms.exceptions.RatingNotExisting;
 import jinookk.ourlms.models.vos.Content;
@@ -12,10 +13,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class RatingTest {
+class RatingTest extends Fixture {
     @Test
     void createdFromDto() {
-        Account account = Account.fake("name");
+        Account account = Fixture.account("name");
         RatingRequestDto ratingRequestDto = new RatingRequestDto(1L, 4, "content");
 
         Rating rating = Rating.of(account, ratingRequestDto);
@@ -32,9 +33,9 @@ class RatingTest {
         List<CourseId> courseIds = List.of(new CourseId(1L), new CourseId(2L));
 
         List<Rating> ratings = List.of(
-                Rating.fake(5.0),
-                Rating.fake(4.0),
-                Rating.fake(3.0)
+                Fixture.rating(5.0),
+                Fixture.rating(4.0),
+                Fixture.rating(3.0)
         );
 
         Double rating = Rating.averageOf(courseIds, ratings);

--- a/src/test/java/jinookk/ourlms/models/entities/SectionTest.java
+++ b/src/test/java/jinookk/ourlms/models/entities/SectionTest.java
@@ -2,6 +2,7 @@ package jinookk.ourlms.models.entities;
 
 import jinookk.ourlms.dtos.SectionRequestDto;
 import jinookk.ourlms.dtos.SectionWithProgressDto;
+import jinookk.ourlms.fixtures.Fixture;
 import jinookk.ourlms.models.vos.Content;
 import jinookk.ourlms.models.vos.Title;
 import jinookk.ourlms.models.vos.ids.CourseId;
@@ -25,9 +26,9 @@ class SectionTest {
 
     @Test
     void convertToDto() {
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
-        Progress progress = Progress.fake("1강");
+        Progress progress = Fixture.progress("1강");
 
         SectionWithProgressDto sectionWithProgressDto = section.toSectionWithProgressDto(List.of(progress));
 
@@ -37,7 +38,7 @@ class SectionTest {
 
     @Test
     void convertToDtoWithInvalidLectureProducts() {
-        Section section = Section.fake("section");
+        Section section = Fixture.section("section");
 
         SectionWithProgressDto sectionWithProgressDto = section.toSectionWithProgressDto(null);
 


### PR DESCRIPTION
문제상황: 프로덕션 코드에서 테스트용 팩토리 메서드 fake를 사용할 수 있었음 -> 의도하지 않은 객체 생성 가능

기존에 엔티티에서 가지고 있던 테스트용 팩토리 메서드 fake를 테스트 모듈의 Fixture라는 팩토리로 전부 옮김